### PR TITLE
Specify max Django version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ author = 'Flávio Juvenal da Silva Junior'
 author_email = 'flavio@vinta.com.br'
 license = 'MIT'
 install_requires = [
-    'Django >= 1.4',
+    'Django >= 1.4, < 2',
     'requests == 2.9.1',
     'boltons == 16.1.1',
     'termcolor == 1.1.0',


### PR DESCRIPTION
fixmydjango-lib does not support Django 2.0 yet. We should pin a max version before trying to support the newest Django version.